### PR TITLE
Fixed a race condition

### DIFF
--- a/main.go
+++ b/main.go
@@ -270,12 +270,12 @@ func syncIDs(sourceURL, destURL string, deletes bool) error {
 					return err
 				default:
 					<-sem
-					go func() {
+					go func(id string) {
 						defer func() { sem <- struct{}{} }()
-						if err := doCopy(sourceURL, destURL, s); err != nil {
+						if err := doCopy(sourceURL, destURL, id); err != nil {
 							errs <- err
 						}
-					}()
+					}(s)
 					output.Created++
 					bar.Increment()
 				}


### PR DESCRIPTION
Sometimes the same id would be sent to the doCopy function.
