### PR TITLE
Added waitgroup to syncIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+up-restutil*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,25 @@
-FROM scratch
-ADD up-restutil up-restutil
-CMD ["/up-restutil"]
+FROM alpine:3.4
+
+ADD  *.go /
+RUN apk update \
+  && apk add bash git go ca-certificates \
+  && ORG_PATH="github.com/Financial-Times" \
+  && REPO_PATH="${ORG_PATH}/up-restutil" \
+  && export GOPATH=/gopath \
+  && mkdir -p $GOPATH/src/${ORG_PATH} \
+  && ln -s ${PWD} $GOPATH/src/${REPO_PATH} \
+  && cd $GOPATH/src/${REPO_PATH} \
+  && go get -t \
+  && go test \
+  && go build ${REPO_PATH} \
+  && apk del go git \
+  && rm -rf $GOPATH /var/cache/apk/*
+
+CMD ./up-restutil \
+    "sync-ids" \
+    --retries=$RETRIES \
+    --sourceFile=$SOURCE_FILE \
+    --destFile=$DEST_FILE \
+    --concurrency=$CONCURRENCY \
+    $SOURCE_URL \
+    $DEST_URL

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## up-restutil
 
+[![Circle CI](https://circleci.com/gh/Financial-Times/up-restutil/tree/master.png?style=shield)](https://circleci.com/gh/Financial-Times/up-restutil/tree/master)
+
 A utility for performing various (typically batched) RESTful operations with JSON resources.
 
 # Installation

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+dependencies:
+  pre:
+    - go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html
+test:
+  override:
+    - gocov test ./... > coverage.json
+  post:
+    - gocov-html coverage.json > $CIRCLE_ARTIFACTS/coverage.html

--- a/main.go
+++ b/main.go
@@ -35,13 +35,13 @@ func main() {
 		dumpFailed := cmd.BoolOpt("dump-failed", false, "dump failed resources to stdout, instead of exiting on failure")
 		concurrency := cmd.IntOpt("concurrency", 16, "number of concurrent requests to use")
 		idProp := cmd.StringArg("IDPROP", "", "property name of identity property")
-		baseUrl := cmd.StringArg("BASEURL", "", "base URL to PUT resources to")
+		baseURL := cmd.StringArg("BASEURL", "", "base URL to PUT resources to")
 		cmd.Action = func() {
 			if *socksProxy != "" {
 				dialer, _ := proxy.SOCKS5("tcp", *socksProxy, nil, proxy.Direct)
 				transport.Dial = dialer.Dial
 			}
-			if err := putAllRest(*baseUrl, *idProp, *user, *pass, *concurrency, *dumpFailed); err != nil {
+			if err := putAllRest(*baseURL, *idProp, *user, *pass, *concurrency, *dumpFailed); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -49,31 +49,46 @@ func main() {
 	})
 
 	app.Command("dump-resources", "Read JSON resources from an endpoint and dump them to stdout", func(cmd *cli.Cmd) {
-		baseUrl := cmd.StringArg("BASEURL", "", "base URL to GET resources from. Must contain a __ids resource")
+		baseURL := cmd.StringArg("BASEURL", "", "base URL to GET resources from. Must contain a __ids resource")
 		throttle := cmd.IntOpt("throttle", 10, "Limit request rate for resource GET requests (requests per second)")
 		cmd.Action = func() {
-			if err := getAllRest(*baseUrl, *throttle); err != nil {
+			if err := getAllRest(*baseURL, *throttle); err != nil {
 				log.Fatal(err)
 			}
 		}
 	})
 
 	app.Command("diff-ids", "Show differences between the ids available in two RESTful collections", func(cmd *cli.Cmd) {
-		sourceUrl := cmd.StringArg("SOURCEURL", "", "base URL to GET resources from. Must contain a __ids resource")
-		destUrl := cmd.StringArg("DESTURL", "", "base URL to GET resources from. Must contain a __ids resource")
+		sourceURL := cmd.StringArg("SOURCEURL", "", "base URL to GET resources from. Must contain a __ids resource")
+		destURL := cmd.StringArg("DESTURL", "", "base URL to GET resources from. Must contain a __ids resource")
 		cmd.Action = func() {
-			if err := diffIDs(*sourceUrl, *destUrl); err != nil {
+			if err := diffIDs(*sourceURL, *destURL); err != nil {
 				log.Fatal(err)
 			}
 		}
 	})
 
-	app.Command("sync-ids", "Sync resources between two RESTul JSON collections, using PUT and DELETE on the destination as needed", func(cmd *cli.Cmd) {
+	app.Command("sync-ids", "Sync resources between two RESTful JSON collections, using PUT and DELETE on the destination as needed", func(cmd *cli.Cmd) {
 		deletes := cmd.BoolOpt("deletes", false, "delete from destination those resources not present in source")
-		sourceUrl := cmd.StringArg("SOURCEURL", "", "base URL to GET resources from. Must contain a __ids resource")
-		destUrl := cmd.StringArg("DESTURL", "", "base URL to GET resources from. Must contain a __ids resource")
+		concurrency := cmd.IntOpt("concurrency", 32, "number of concurrent requests to use")
+		minExecTime := cmd.IntOpt("minExecTime", 0, "minimum amount of seconds it will take to execute one sync operation")
+		retries := cmd.IntOpt("retries", 2, "number of times a sync should be retried if it fails")
+		sourceFile := cmd.StringOpt("sourceFile", "", "path to the file the contains the source ids")
+		destFile := cmd.StringOpt("destFile", "", "path to the file that contains the destination ids")
+		sourceURL := cmd.StringArg("SOURCEURL", "", "base URL to GET resources from. Must contain a __ids resource")
+		destURL := cmd.StringArg("DESTURL", "", "base URL to GET resources from. Must contain a __ids resource")
 		cmd.Action = func() {
-			if err := syncIDs(*sourceUrl, *destUrl, *deletes); err != nil {
+			config := &syncConfig{
+				destIdsRetriever:   getIDListRetriever(*destFile, *destURL),
+				sourceIdsRetriever: getIDListRetriever(*sourceFile, *sourceURL),
+				deletes:            *deletes,
+				maxConcurrentReqs:  *concurrency,
+				minExecTime:        *minExecTime,
+				destURL:            *destURL,
+				sourceURL:          *sourceURL,
+				retries:            *retries,
+			}
+			if err := syncIDs(config); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -82,7 +97,7 @@ func main() {
 	app.Run(os.Args)
 }
 
-func putAllRest(baseurl string, idProperty string, user string, pass string, conns int, dumpFailed bool) error {
+func putAllRest(baseURL string, idProperty string, user string, pass string, conns int, dumpFailed bool) error {
 
 	dec := json.NewDecoder(os.Stdin)
 
@@ -90,7 +105,7 @@ func putAllRest(baseurl string, idProperty string, user string, pass string, con
 
 	transport.MaxIdleConnsPerHost = conns
 
-	rp := &resourcePutter{baseurl, idProperty, user, pass}
+	rp := &resourcePutter{baseURL, idProperty, user, pass}
 
 	errs := make(chan error, 1)
 
@@ -204,7 +219,7 @@ func diffIDs(sourceURL, destURL string) error {
 	output.OnlyInSource = []string{}
 	output.OnlyInDestination = []string{}
 
-	for s, _ := range sources {
+	for s := range sources {
 		if _, found := dests[s]; !found {
 			output.OnlyInSource = append(output.OnlyInSource, s)
 		} else {
@@ -213,7 +228,7 @@ func diffIDs(sourceURL, destURL string) error {
 
 	}
 
-	for s, _ := range dests {
+	for s := range dests {
 		output.OnlyInDestination = append(output.OnlyInDestination, s)
 	}
 
@@ -221,12 +236,24 @@ func diffIDs(sourceURL, destURL string) error {
 
 }
 
-func syncIDs(sourceURL, destURL string, deletes bool) error {
-	sourceIDs := make(chan string)
-	go fetchIDList(sourceURL, sourceIDs)
+type syncConfig struct {
+	sourceURL          string
+	destURL            string
+	sourceIdsRetriever IDListRetriever
+	destIdsRetriever   IDListRetriever
+	maxConcurrentReqs  int
+	minExecTime        int
+	retries            int
+	deletes            bool
+}
 
+func syncIDs(config *syncConfig) error {
+	errChan := make(chan error)
+	defer close(errChan)
+	sourceIDs := make(chan string)
+	go config.sourceIdsRetriever.Retrieve(sourceIDs, errChan)
 	destIDs := make(chan string)
-	go fetchIDList(destURL, destIDs)
+	go config.destIdsRetriever.Retrieve(destIDs, errChan)
 
 	sources := make(map[string]struct{})
 	dests := make(map[string]struct{})
@@ -245,6 +272,8 @@ func syncIDs(sourceURL, destURL string, deletes bool) error {
 			} else {
 				dests[destID] = struct{}{}
 			}
+		case err := <-errChan:
+			return err
 		}
 	}
 
@@ -253,7 +282,7 @@ func syncIDs(sourceURL, destURL string, deletes bool) error {
 		Deleted int `json:"created"`
 	}
 
-	sem := make(chan struct{}, 64)
+	sem := make(chan struct{}, config.maxConcurrentReqs)
 	for i := 0; i < cap(sem); i++ {
 		sem <- struct{}{}
 	}
@@ -264,7 +293,7 @@ func syncIDs(sourceURL, destURL string, deletes bool) error {
 		var wg sync.WaitGroup
 		bar := pb.StartNew(len(sources))
 
-		for s, _ := range sources {
+		for s := range sources {
 			if _, found := dests[s]; !found {
 				select {
 				case err := <-errs:
@@ -277,24 +306,28 @@ func syncIDs(sourceURL, destURL string, deletes bool) error {
 							sem <- struct{}{}
 							wg.Done()
 						}()
-						retry := 2 //TODO parameterize
+						minExecTime := time.After(time.Second * time.Duration(config.minExecTime))
+						retry := config.retries
 						for {
-							if err := doCopy(sourceURL, destURL, id); err != nil {
+							if err := doCopy(config.sourceURL, config.destURL, id); err != nil {
 								if retry == 0 {
 									errs <- err
+									break
 								} else {
 									retry--
 									time.Sleep(time.Second * 2)
 								}
 							} else {
-								return
+								break
 							}
 						}
+						<-minExecTime
 					}(s)
 					output.Created++
 					bar.Increment()
 				}
 			} else {
+				bar.Increment()
 				delete(dests, s)
 			}
 
@@ -303,11 +336,11 @@ func syncIDs(sourceURL, destURL string, deletes bool) error {
 		bar.FinishPrint("Done creates")
 	}
 
-	if deletes && len(dests) > 0 {
+	if config.deletes && len(dests) > 0 {
 		bar := pb.StartNew(len(dests))
 
-		for s, _ := range dests {
-			if err := doDelete(destURL, s); err != nil {
+		for s := range dests {
+			if err := doDelete(config.destURL, s); err != nil {
 				return err
 			}
 			output.Deleted++
@@ -317,7 +350,6 @@ func syncIDs(sourceURL, destURL string, deletes bool) error {
 	}
 
 	return json.NewEncoder(os.Stdout).Encode(output)
-
 }
 
 func doCopy(sourceURL, destURL, id string) error {
@@ -355,6 +387,7 @@ func doCopy(sourceURL, destURL, id string) error {
 		return err
 	}
 	dreq.Header.Set("User-Agent", useragent)
+	dreq.Header.Set("Content-type", "application/json")
 	dresp, err := httpClient.Do(dreq)
 	if err != nil {
 		return err
@@ -407,7 +440,7 @@ func (rp *resourcePutter) putAll(resources <-chan resource, failChan chan []byte
 		if err != nil {
 			return err
 		}
-		b := rp.baseUrl
+		b := rp.baseURL
 		if !strings.HasSuffix(b, "/") {
 			b = b + "/"
 		}
@@ -526,7 +559,7 @@ func fetchIDList(baseURL string, ids chan<- string) {
 	defer resp.Body.Close()
 
 	type listEntry struct {
-		ID string `json:id`
+		ID string `json:"id"`
 	}
 
 	var le listEntry
@@ -583,7 +616,7 @@ var (
 type resource map[string]interface{}
 
 type resourcePutter struct {
-	baseUrl    string
+	baseURL    string
 	idProperty string
 	user       string
 	pass       string

--- a/retriever.go
+++ b/retriever.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+)
+
+var uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+func getIDListRetriever(filePath string, URL string) IDListRetriever {
+	if filePath != "" {
+		return newFileBasedIDListRetriever(filePath)
+	}
+	return newURLBasedIDListRetriever(URL, httpClient)
+}
+
+func newFileBasedIDListRetriever(filePath string) *fileBasedIDListRetriever {
+	return &fileBasedIDListRetriever{filePath: filePath}
+}
+
+func newURLBasedIDListRetriever(baseURL string, client *http.Client) *urlBasedIDListRetriever {
+	return &urlBasedIDListRetriever{
+		baseURL: baseURL,
+		client:  client}
+}
+
+//IDListRetriever is the interface used for retrieving UUIDs from a provided source
+//
+//Retrieve receives 2 unbuffered channels, one for IDs and the other for errors, and populates them accordingly as the
+//function runs.
+type IDListRetriever interface {
+	Retrieve(chan<- string, chan<- error)
+}
+
+type fileBasedIDListRetriever struct {
+	filePath string
+}
+
+func (r *fileBasedIDListRetriever) Retrieve(ids chan<- string, errChan chan<- error) {
+	defer close(ids)
+	inputFile, err := os.Open(r.filePath)
+	if err != nil {
+		errChan <- fmt.Errorf("ERROR - Failed opening file=%s: %s", r.filePath, err)
+		return
+	}
+	defer inputFile.Close()
+
+	scanner := bufio.NewScanner(inputFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if uuidPattern.MatchString(line) {
+			ids <- line
+		} else {
+			errChan <- fmt.Errorf("ERROR - Found invalid ID=%s in file=%s", line, r.filePath)
+			return
+		}
+	}
+}
+
+type urlBasedIDListRetriever struct {
+	client  *http.Client
+	baseURL string
+}
+
+func (r *urlBasedIDListRetriever) Retrieve(ids chan<- string, errChan chan<- error) {
+	defer close(ids)
+	u, err := url.Parse(r.baseURL)
+	if err != nil {
+		errChan <- fmt.Errorf("ERROR - %s", err)
+		return
+	}
+	u, err = u.Parse("./__ids")
+	if err != nil {
+		errChan <- fmt.Errorf("ERROR - %s", err)
+		return
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		errChan <- fmt.Errorf("ERROR - %s", err)
+		return
+	}
+	req.Header.Set("User-Agent", useragent)
+	resp, err := r.client.Do(req)
+	if err != nil {
+		errChan <- fmt.Errorf("ERROR - %s", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	type listEntry struct {
+		ID string `json:"id"`
+	}
+
+	var le listEntry
+	dec := json.NewDecoder(resp.Body)
+	for {
+		err = dec.Decode(&le)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			errChan <- fmt.Errorf("ERROR - %s", err)
+		}
+		ids <- le.ID
+	}
+}

--- a/retriever_test.go
+++ b/retriever_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/h2non/gock"
+	"github.com/nbio/st"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestFileBasedRetrieve_Success(t *testing.T) {
+	inputFilePath := "retriever_test"
+	inputFile, err := os.OpenFile(inputFilePath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		t.Errorf("Failed opening test file=%s, %s", inputFilePath, err)
+		return
+	}
+	defer os.Remove(inputFilePath)
+
+	var expectedIds []string
+	expectedIds = append(expectedIds, "2d3e16e0-61cb-4322-8aff-3b01c59f4daa", "fd4459b2-cc4e-4ec8-9853-c5238eb860fb")
+
+	for _, id := range expectedIds {
+		inputFile.WriteString(id)
+		inputFile.WriteString("\n")
+	}
+	inputFile.Close()
+
+	retriever := newFileBasedIDListRetriever(inputFilePath)
+	var idsChan = make(chan string)
+	var errChan = make(chan error)
+	var actualIds = make(map[string]struct{})
+
+	go retriever.Retrieve(idsChan, errChan)
+
+	for idsChan != nil {
+		select {
+		case id, ok := <-idsChan:
+			if !ok {
+				idsChan = nil
+			} else {
+				actualIds[id] = struct{}{}
+			}
+		case err := <-errChan:
+			t.Errorf("Error not expected: %s", err)
+			return
+		}
+	}
+
+	for _, id := range expectedIds {
+		if _, found := actualIds[id]; !found {
+			st.Expect(t, true, found)
+			return
+		}
+	}
+}
+
+func TestFileBasedRetrieve_FileOpenFailure(t *testing.T) {
+	expectedError := errors.New("ERROR - Failed opening file=non_existing_file: open non_existing_file: The system cannot find the file specified.")
+	retriever := newFileBasedIDListRetriever("non_existing_file")
+	var idsChan = make(chan string)
+	var errChan = make(chan error)
+
+	go retriever.Retrieve(idsChan, errChan)
+
+	for idsChan != nil {
+		select {
+		case _, ok := <-idsChan:
+			if !ok {
+				idsChan = nil
+			}
+		case actualError := <-errChan:
+			if expectedError != actualError {
+				st.Expect(t, expectedError, actualError)
+			}
+			return
+		}
+	}
+	t.Error("Expected error but no error was returned")
+}
+
+func TestFileBasedRetrieve_InvalidIdFailure(t *testing.T) {
+	var invalidIds []string
+	invalidIds = append(
+		invalidIds,
+		"2d3e16e-61cb-4322-8aff-3b01c59f4daa",
+		"2d3e16e0-1cb-4322-8aff-3b01c59f4daa",
+		"2d3e16e0-61cb-322-8aff-3b01c59f4daa",
+		"2d3e16e0-61cb-4322-aff-3b01c59f4daa",
+		"2d3e16e0-61cb-4322-8aff-3b01c59f4da",
+		"2d3e16e0-61cb-4322-8aff-3b01c59f4da",
+		"2d3e16e0-61cb-4322-8aff-3b01c59f4da",
+		"2d3e16e0-61cb-4322-8aff-3b01c59f4da",
+		"2d3e16e0-61cb-4322-8aff-3b01c59f4da",
+		"2d3e16e0-61cb-4322-8aff-3b01c59f4da",
+		"gd3e16e0-61cb-4322-8aff-3b01c59f4daa",
+		"2d3e16e0-61cb-4322-8aff-3b01c59f4daa-",
+		"-2d3e16e0-61cb-4322-8aff-3b01c59f4daa")
+
+	for _, invalidID := range invalidIds {
+		retrieveInvalidID(t, invalidID)
+	}
+}
+
+func retrieveInvalidID(t *testing.T, invalidID string) {
+	expectedError := fmt.Errorf("ERROR - Found invalid ID=%s in file=retriever_test", invalidID)
+	inputFilePath := "retriever_test"
+	inputFile, err := os.OpenFile(inputFilePath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		t.Errorf("Failed opening test file=%s, %s", inputFilePath, err)
+		return
+	}
+	defer os.Remove(inputFilePath)
+
+	inputFile.WriteString(invalidID)
+	inputFile.WriteString("\n")
+	inputFile.Close()
+
+	retriever := newFileBasedIDListRetriever(inputFilePath)
+	var idsChan = make(chan string)
+	var errChan = make(chan error)
+
+	go retriever.Retrieve(idsChan, errChan)
+
+	for idsChan != nil {
+		select {
+		case _, ok := <-idsChan:
+			if !ok {
+				idsChan = nil
+			}
+		case actualError := <-errChan:
+			if expectedError != actualError {
+				st.Expect(t, expectedError, actualError)
+			}
+			return
+		}
+	}
+	t.Error("Expected error but no error was returned")
+}
+
+func TestUrlBasedRetrieve_Success(t *testing.T) {
+	defer gock.Off()
+	gock.New("http://localhost").
+		Get("/endpoint/__ids").
+		Reply(200).
+		JSON(map[string]string{"id": "c0de16de-00e6-3d52-aca5-c2a300cd1144"})
+
+	var expectedIds []string
+	expectedIds = append(expectedIds, "c0de16de-00e6-3d52-aca5-c2a300cd1144")
+
+	retriever := newURLBasedIDListRetriever("http://localhost/endpoint/", http.DefaultClient)
+	var idsChan = make(chan string)
+	var errChan = make(chan error)
+	var actualIds = make(map[string]struct{})
+
+	go retriever.Retrieve(idsChan, errChan)
+
+	for idsChan != nil {
+		select {
+		case id, ok := <-idsChan:
+			if !ok {
+				idsChan = nil
+			} else {
+				actualIds[id] = struct{}{}
+			}
+		case err := <-errChan:
+			t.Errorf("Error not expected: %s", err)
+			return
+		}
+	}
+
+	for _, id := range expectedIds {
+		if _, found := actualIds[id]; !found {
+			st.Expect(t, true, found)
+			return
+		}
+	}
+
+	st.Expect(t, gock.IsDone(), true)
+}
+
+func TestUrlBasedRetrieve_InvalidUrlFailure(t *testing.T) {
+	expectedError := errors.New("ERROR - parse :http//localhost/endpoint/: missing protocol scheme")
+	retriever := newURLBasedIDListRetriever(":http//localhost/endpoint/", http.DefaultClient)
+	var idsChan = make(chan string)
+	var errChan = make(chan error)
+
+	go retriever.Retrieve(idsChan, errChan)
+
+	for idsChan != nil {
+		select {
+		case _, ok := <-idsChan:
+			if !ok {
+				idsChan = nil
+			}
+		case actualError := <-errChan:
+			if expectedError != actualError {
+				st.Expect(t, expectedError, actualError)
+			}
+			return
+		}
+	}
+
+	st.Expect(t, gock.IsDone(), true)
+}
+
+func TestUrlBasedRetrieve_InvalidResponseFailure(t *testing.T) {
+	defer gock.Off()
+	gock.New("http://localhost").
+		Get("/endpoint/__ids").
+		Reply(200).BodyString("Invalid response")
+	expectedError := errors.New("ERROR - invalid character 'I' looking for beginning of value")
+
+	retriever := newURLBasedIDListRetriever("http://localhost/endpoint/", http.DefaultClient)
+	var idsChan = make(chan string)
+	var errChan = make(chan error)
+
+	go retriever.Retrieve(idsChan, errChan)
+
+	for idsChan != nil {
+		select {
+		case _, ok := <-idsChan:
+			if !ok {
+				idsChan = nil
+			}
+		case actualError := <-errChan:
+			if expectedError != actualError {
+				st.Expect(t, expectedError, actualError)
+			}
+			return
+		}
+	}
+
+	st.Expect(t, gock.IsDone(), true)
+}

--- a/retriever_test.go
+++ b/retriever_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/h2non/gock"
 	"github.com/nbio/st"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"
 	"testing"
@@ -58,7 +59,7 @@ func TestFileBasedRetrieve_Success(t *testing.T) {
 }
 
 func TestFileBasedRetrieve_FileOpenFailure(t *testing.T) {
-	expectedError := errors.New("ERROR - Failed opening file=non_existing_file: open non_existing_file: The system cannot find the file specified.")
+	expectedError := "ERROR - Failed opening file=non_existing_file:"
 	retriever := newFileBasedIDListRetriever("non_existing_file")
 	var idsChan = make(chan string)
 	var errChan = make(chan error)
@@ -72,9 +73,7 @@ func TestFileBasedRetrieve_FileOpenFailure(t *testing.T) {
 				idsChan = nil
 			}
 		case actualError := <-errChan:
-			if expectedError != actualError {
-				st.Expect(t, expectedError, actualError)
-			}
+			assert.Contains(t, actualError.Error(), expectedError)
 			return
 		}
 	}


### PR DESCRIPTION
We need to wait for the goroutines to finish before continuing or we risk not finishing every copy operation before the main thread ends.

_Note_: Dockerized only for our use case of sync-ids; in the future this should be improved
